### PR TITLE
✨Feature: User 도메인 추가

### DIFF
--- a/src/main/java/com/wanted/babdoduk/user/domain/entity/User.java
+++ b/src/main/java/com/wanted/babdoduk/user/domain/entity/User.java
@@ -1,0 +1,50 @@
+package com.wanted.babdoduk.user.domain.entity;
+
+import com.wanted.babdoduk.common.domain.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(name = "username")
+    private String username;
+
+    @Column(name = "password")
+    private String encodedPassword;
+
+    @Column(name = "lat")
+    private BigDecimal latitude;
+
+    @Column(name = "lon")
+    private BigDecimal longitude;
+
+    @Column(name = "lunch_push_approved")
+    private Boolean lunchPushApproved;
+
+    @Builder
+    public User(String username,
+            String encodedPassword,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            Boolean lunchPushApproved) {
+        this.username = username;
+        this.encodedPassword = encodedPassword;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.lunchPushApproved = lunchPushApproved;
+    }
+}

--- a/src/main/java/com/wanted/babdoduk/user/domain/entity/User.java
+++ b/src/main/java/com/wanted/babdoduk/user/domain/entity/User.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "users")
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/wanted/babdoduk/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/wanted/babdoduk/user/domain/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.wanted.babdoduk.user.domain.repository;
+
+import com.wanted.babdoduk.user.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}


### PR DESCRIPTION
## 💻 작업 내역

### ✓ User Entity 추가

- `User`, `UserRepository` 정의
  - `User`는 `BaseTimeEntity`를 상속받는 Entity 객체입니다.
  - `User`의 멤버 변수 `latitude`, `longitude`에는 [Restaurant 도메인 추가] 작업에서와 같이 `BigDecimal` 타입을 적용해 소수점 이하 자리수들을 정확하게 나타낼 수 있도록 했습니다.

## 🔎 PR 특이 사항

- `User` Entity가 기능의 비즈니스 로직에 적용되는 @newnyee님, @buhee1029님을 Reviewer로 선정했습니다.
- 구현 과정에서 별도의 특이사항은 없습니다.

[Restaurant 도메인 추가]: https://github.com/wanted-pre-onboarding-backend-team-s/bab-doduk/pull/3#issue-1971976895