### PR TITLE
🐛 Bugfix: 테스트 코드 에러 수정 및 전체 테스트 수행 시 `@SpringBootTest` 테스트 제외

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,4 +59,9 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+
+	filter {
+		excludeTestsMatching 'com.wanted.babdoduk.batch.client.OpenRestaurantClientTest'
+		excludeTestsMatching 'com.wanted.babdoduk.BabDodukApplicationTests'
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.security:spring-security-web'
 
 	// feign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.4'
@@ -57,7 +56,6 @@ dependencies {
 
 	// Auth0 JWT
 	implementation 'com.auth0:java-jwt:4.4.0'
-
 }
 
 tasks.named('test') {
@@ -65,6 +63,8 @@ tasks.named('test') {
 
 	filter {
 		excludeTestsMatching 'com.wanted.babdoduk.batch.client.OpenRestaurantClientTest'
+		excludeTestsMatching 'com.wanted.babdoduk.restaurant.domain.review.service.ReviewServiceTest'
+		excludeTestsMatching 'com.wanted.babdoduk.restaurant.domain.review.service.ReviewStatServiceTest'
 		excludeTestsMatching 'com.wanted.babdoduk.BabDodukApplicationTests'
 	}
 }

--- a/src/test/java/com/wanted/babdoduk/restaurant/domain/restaurant/repository/RestaurantRepositoryImplTest.java
+++ b/src/test/java/com/wanted/babdoduk/restaurant/domain/restaurant/repository/RestaurantRepositoryImplTest.java
@@ -2,6 +2,8 @@ package com.wanted.babdoduk.restaurant.domain.restaurant.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.wanted.babdoduk.batch.client.RawRestaurantRepository;
+import com.wanted.babdoduk.batch.service.OpenRestaurantService;
 import com.wanted.babdoduk.common.config.querydsl.QueryDslConfig;
 import com.wanted.babdoduk.restaurant.domain.restaurant.entity.Restaurant;
 import com.wanted.babdoduk.restaurant.domain.restaurant.enums.SortType;
@@ -17,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.test.context.ActiveProfiles;
@@ -27,6 +30,7 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(locations = "classpath:application-test.yml")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(QueryDslConfig.class)
+@MockBean(OpenRestaurantService.class)
 class RestaurantRepositoryImplTest {
 
     private static final String MY_LATITUDE = "37.397569";

--- a/src/test/java/com/wanted/babdoduk/session/controller/SessionControllerTest.java
+++ b/src/test/java/com/wanted/babdoduk/session/controller/SessionControllerTest.java
@@ -9,6 +9,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.wanted.babdoduk.batch.client.RawRestaurantRepository;
+import com.wanted.babdoduk.batch.service.OpenRestaurantService;
 import com.wanted.babdoduk.session.dto.LoginRequestDto;
 import com.wanted.babdoduk.session.dto.LoginResultDto;
 import com.wanted.babdoduk.session.service.LoginService;
@@ -24,6 +26,8 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(SessionController.class)
 @MockBean(JpaMetamodelMappingContext.class)
+@MockBean(OpenRestaurantService.class)
+@MockBean(RawRestaurantRepository.class)
 class SessionControllerTest {
 
     @Autowired

--- a/src/test/java/com/wanted/babdoduk/user/controller/UserControllerTest.java
+++ b/src/test/java/com/wanted/babdoduk/user/controller/UserControllerTest.java
@@ -9,6 +9,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.wanted.babdoduk.batch.client.RawRestaurantRepository;
+import com.wanted.babdoduk.batch.service.OpenRestaurantService;
 import com.wanted.babdoduk.user.dto.CreateUserRequestDto;
 import com.wanted.babdoduk.user.dto.CreateUserResponseDto;
 import com.wanted.babdoduk.user.service.CreateUserService;
@@ -24,6 +26,8 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(UserController.class)
 @MockBean(JpaMetamodelMappingContext.class)
+@MockBean(OpenRestaurantService.class)
+@MockBean(RawRestaurantRepository.class)
 class UserControllerTest {
 
     @Autowired


### PR DESCRIPTION
## 💻 작업 내역

- OpenAPI 비즈니스 로직이 루트 클래스 BabDodukApplication에 포함되어 `@SpringBootTest` 수행 시 실제로 OpenAPI 데이터 호출 및 배치 처리가 수행되어 테스트 결과 확인이 지연되는 문제를 확인했습니다.
- 우선 전체 테스트 수행 시 `@SpringBootTest` 테스트 클래스가 포함된 package를 제외하고 테스트를 수행하도록 수정했습니다.
  - `build.gradle`에 수행하지 않을 테스트 클래스를 직접 포함시킨 방식이라, 이후 추가되는 `@SpringBootTest`도 필요하다면 직접 추가되어야 할 것 같습니다.
- 그 외 슬라이스 테스트 수행 시 의존성이 추가되지 않아 에러가 발생하는 테스트에 대해 Mock 의존성을 추가했습니다.

## 🔎 PR 특이 사항

### 이슈

- 테스트에서 제외된 `@SpringBootTest`는 개별적으로 수행은 가능하지만, 여전히 `count()`와 `initSave()`를 호출한 뒤 테스트를 수행하는 것 같습니다.
- 추후 스케줄러를 적용해 OpenAPI 비즈니스 로직이 분리되는 경우, `@SpringBootTest` 수행 지연 문제는 해결될 것으로 보입니다. 해당 로직이 적용되는 경우에는 제외된 테스트를 다시 복귀시킬 수 있을 것 같습니다.