### PR TITLE
✨ Feature: 인증

### DIFF
--- a/src/main/java/com/wanted/babdoduk/common/config/mvc/WebMvcConfig.java
+++ b/src/main/java/com/wanted/babdoduk/common/config/mvc/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.wanted.babdoduk.common.config.mvc;
+
+import com.wanted.babdoduk.common.interceptor.AuthenticationInterceptor;
+import com.wanted.babdoduk.common.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AuthenticationInterceptor(jwtUtil));
+    }
+}

--- a/src/main/java/com/wanted/babdoduk/common/domain/enums/RequestUnauthenticated.java
+++ b/src/main/java/com/wanted/babdoduk/common/domain/enums/RequestUnauthenticated.java
@@ -3,8 +3,11 @@ package com.wanted.babdoduk.common.domain.enums;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpMethod;
 
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public enum RequestUnauthenticated {
     PostUsers(HttpMethod.POST.name(), "/api/v1/users"),
     PostSessions(HttpMethod.POST.name(), "/api/v1/sessions");
@@ -15,11 +18,6 @@ public enum RequestUnauthenticated {
     private static final List<RequestUnauthenticated> REQUESTS_UNAUTHENTICATED
             = Arrays.stream(RequestUnauthenticated.values())
             .toList();
-
-    RequestUnauthenticated(String method, String path) {
-        this.method = method;
-        this.path = path;
-    }
 
     public static boolean contains(HttpServletRequest request) {
         return REQUESTS_UNAUTHENTICATED

--- a/src/main/java/com/wanted/babdoduk/common/domain/enums/RequestUnauthenticated.java
+++ b/src/main/java/com/wanted/babdoduk/common/domain/enums/RequestUnauthenticated.java
@@ -1,0 +1,32 @@
+package com.wanted.babdoduk.common.domain.enums;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.http.HttpMethod;
+
+public enum RequestUnauthenticated {
+    PostUsers(HttpMethod.POST.name(), "/api/v1/users"),
+    PostSessions(HttpMethod.POST.name(), "/api/v1/sessions");
+
+    private final String method;
+    private final String path;
+
+    private static final List<RequestUnauthenticated> REQUESTS_UNAUTHENTICATED
+            = Arrays.stream(RequestUnauthenticated.values())
+            .toList();
+
+    RequestUnauthenticated(String method, String path) {
+        this.method = method;
+        this.path = path;
+    }
+
+    public static boolean contains(HttpServletRequest request) {
+        return REQUESTS_UNAUTHENTICATED
+                .stream()
+                .anyMatch(RequestUnauthenticated -> {
+                    return RequestUnauthenticated.method.equals(request.getMethod())
+                            && RequestUnauthenticated.path.equals(request.getRequestURI());
+                });
+    }
+}

--- a/src/main/java/com/wanted/babdoduk/common/exception/ErrorType.java
+++ b/src/main/java/com/wanted/babdoduk/common/exception/ErrorType.java
@@ -1,6 +1,10 @@
 package com.wanted.babdoduk.common.exception;
 
+import com.wanted.babdoduk.common.interceptor.exception.InvalidRequestHeaderAuthorizationException;
+import com.wanted.babdoduk.common.interceptor.exception.MissingRequestHeaderAuthorizationException;
+import com.wanted.babdoduk.session.exception.AccessTokenExpiredException;
 import com.wanted.babdoduk.session.exception.PasswordMismatchedException;
+import com.wanted.babdoduk.session.exception.TokenDecodingFailedException;
 import com.wanted.babdoduk.session.exception.TokenIssuanceFailedException;
 import com.wanted.babdoduk.restaurant.domain.review.exception.ReviewNotFoundException;
 import com.wanted.babdoduk.sigungu.exception.FailedGetSiGunGuException;
@@ -24,7 +28,13 @@ public enum ErrorType {
     U003("U003", "존재하지 않는 사용자입니다.", UserNotFoundException.class, HttpStatus.NOT_FOUND),
 
     SE001("SE001", "비밀번호가 일치하지 않습니다.", PasswordMismatchedException.class, HttpStatus.BAD_REQUEST),
-    SE002("SE002", "토큰 생성에 실패했습니다.", TokenIssuanceFailedException.class, HttpStatus.INTERNAL_SERVER_ERROR),
+
+    AU001("AU001", "액세스 토큰이 없습니다.", MissingRequestHeaderAuthorizationException.class, HttpStatus.UNAUTHORIZED),
+    AU002("AU002", "잘못된 액세스 토큰 전달자 형식입니다.", InvalidRequestHeaderAuthorizationException.class, HttpStatus.UNAUTHORIZED),
+    AU003("AU003", "액세스 토큰이 만료되었습니다.", AccessTokenExpiredException.class, HttpStatus.UNAUTHORIZED),
+
+    T001("T001", "토큰 생성에 실패했습니다.", TokenIssuanceFailedException.class, HttpStatus.INTERNAL_SERVER_ERROR),
+    T002("T002", "토큰 디코딩에 실패했습니다.", TokenDecodingFailedException.class, HttpStatus.INTERNAL_SERVER_ERROR),
 
     S001("S001", "시도, 시군구 목록을 불러올 수 없습니다.", FailedGetSiGunGuException.class, HttpStatus.INTERNAL_SERVER_ERROR),
     R001("R001", "식당이 존재하지 않습니다.", NotFoundRestaurantException.class, HttpStatus.NOT_FOUND),

--- a/src/main/java/com/wanted/babdoduk/common/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/wanted/babdoduk/common/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,59 @@
+package com.wanted.babdoduk.common.interceptor;
+
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.wanted.babdoduk.common.domain.enums.RequestUnauthenticated;
+import com.wanted.babdoduk.common.interceptor.exception.InvalidRequestHeaderAuthorizationException;
+import com.wanted.babdoduk.common.interceptor.exception.MissingRequestHeaderAuthorizationException;
+import com.wanted.babdoduk.common.util.JwtUtil;
+import com.wanted.babdoduk.session.exception.AccessTokenExpiredException;
+import com.wanted.babdoduk.session.exception.TokenDecodingFailedException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@RequiredArgsConstructor
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER = "Bearer ";
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler
+    ) {
+        if (RequestUnauthenticated.contains(request)) {
+            return true;
+        }
+
+        String authorization = request.getHeader(AUTHORIZATION);
+
+        if (authorization == null) {
+            throw new MissingRequestHeaderAuthorizationException();
+        }
+
+        if (!authorization.startsWith(BEARER)) {
+            throw new InvalidRequestHeaderAuthorizationException();
+        }
+
+        String accessToken = authorization.substring(BEARER.length());
+
+        try {
+            Long userId = jwtUtil.decodeAccessToken(accessToken);
+
+            request.setAttribute("userId", userId);
+
+            return true;
+        } catch (TokenExpiredException exception) {
+            throw new AccessTokenExpiredException();
+
+        } catch (JWTDecodeException exception) {
+            throw new TokenDecodingFailedException();
+        }
+    }
+}

--- a/src/main/java/com/wanted/babdoduk/common/interceptor/exception/InvalidRequestHeaderAuthorizationException.java
+++ b/src/main/java/com/wanted/babdoduk/common/interceptor/exception/InvalidRequestHeaderAuthorizationException.java
@@ -1,0 +1,7 @@
+package com.wanted.babdoduk.common.interceptor.exception;
+
+import com.wanted.babdoduk.common.exception.WantedException;
+
+public class InvalidRequestHeaderAuthorizationException extends WantedException {
+
+}

--- a/src/main/java/com/wanted/babdoduk/common/interceptor/exception/MissingRequestHeaderAuthorizationException.java
+++ b/src/main/java/com/wanted/babdoduk/common/interceptor/exception/MissingRequestHeaderAuthorizationException.java
@@ -1,0 +1,7 @@
+package com.wanted.babdoduk.common.interceptor.exception;
+
+import com.wanted.babdoduk.common.exception.WantedException;
+
+public class MissingRequestHeaderAuthorizationException extends WantedException {
+
+}

--- a/src/main/java/com/wanted/babdoduk/common/util/JwtUtil.java
+++ b/src/main/java/com/wanted/babdoduk/common/util/JwtUtil.java
@@ -4,11 +4,14 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class JwtUtil {
+
+    private static final String CLAIM_USER_ID = "userId";
 
     private final Algorithm algorithm;
     private final Long validTimeAccessToken;
@@ -19,7 +22,7 @@ public class JwtUtil {
         Date expirationDateAccessToken = new Date(now.getTime() + validTimeAccessToken);
 
         return JWT.create()
-                .withClaim("userId", userId)
+                .withClaim(CLAIM_USER_ID, userId)
                 .withExpiresAt(expirationDateAccessToken)
                 .sign(algorithm);
     }
@@ -29,9 +32,17 @@ public class JwtUtil {
         Date expirationDateRefreshToken = new Date(now.getTime() + validTimeRefreshToken);
 
         return JWT.create()
-                .withClaim("userId", userId)
+                .withClaim(CLAIM_USER_ID, userId)
                 .withExpiresAt(expirationDateRefreshToken)
                 .sign(algorithm);
+    }
+
+    public Long decodeAccessToken(String token) {
+        JWTVerifier verifier = JWT.require(algorithm)
+                .build();
+        DecodedJWT verified = verifier.verify(token);
+        return verified.getClaim(CLAIM_USER_ID)
+                .asLong();
     }
 
     public boolean isTokenExpired(String token) {

--- a/src/main/java/com/wanted/babdoduk/session/exception/AccessTokenExpiredException.java
+++ b/src/main/java/com/wanted/babdoduk/session/exception/AccessTokenExpiredException.java
@@ -1,0 +1,7 @@
+package com.wanted.babdoduk.session.exception;
+
+import com.wanted.babdoduk.common.exception.WantedException;
+
+public class AccessTokenExpiredException extends WantedException {
+
+}

--- a/src/main/java/com/wanted/babdoduk/session/exception/TokenDecodingFailedException.java
+++ b/src/main/java/com/wanted/babdoduk/session/exception/TokenDecodingFailedException.java
@@ -1,0 +1,7 @@
+package com.wanted.babdoduk.session.exception;
+
+import com.wanted.babdoduk.common.exception.WantedException;
+
+public class TokenDecodingFailedException extends WantedException {
+
+}

--- a/src/test/java/com/wanted/babdoduk/session/controller/SessionControllerTest.java
+++ b/src/test/java/com/wanted/babdoduk/session/controller/SessionControllerTest.java
@@ -11,6 +11,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.wanted.babdoduk.batch.client.RawRestaurantRepository;
 import com.wanted.babdoduk.batch.service.OpenRestaurantService;
+import com.wanted.babdoduk.common.config.jwt.JwtConfig;
+import com.wanted.babdoduk.common.config.mvc.WebMvcConfig;
 import com.wanted.babdoduk.session.dto.LoginRequestDto;
 import com.wanted.babdoduk.session.dto.LoginResultDto;
 import com.wanted.babdoduk.session.service.LoginService;
@@ -20,11 +22,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(SessionController.class)
+@Import({WebMvcConfig.class, JwtConfig.class})
 @MockBean(JpaMetamodelMappingContext.class)
 @MockBean(OpenRestaurantService.class)
 @MockBean(RawRestaurantRepository.class)

--- a/src/test/java/com/wanted/babdoduk/user/controller/UserControllerTest.java
+++ b/src/test/java/com/wanted/babdoduk/user/controller/UserControllerTest.java
@@ -11,6 +11,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.wanted.babdoduk.batch.client.RawRestaurantRepository;
 import com.wanted.babdoduk.batch.service.OpenRestaurantService;
+import com.wanted.babdoduk.common.config.jwt.JwtConfig;
+import com.wanted.babdoduk.common.config.mvc.WebMvcConfig;
 import com.wanted.babdoduk.user.dto.CreateUserRequestDto;
 import com.wanted.babdoduk.user.dto.CreateUserResponseDto;
 import com.wanted.babdoduk.user.service.CreateUserService;
@@ -20,11 +22,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(UserController.class)
+@Import({WebMvcConfig.class, JwtConfig.class})
 @MockBean(JpaMetamodelMappingContext.class)
 @MockBean(OpenRestaurantService.class)
 @MockBean(RawRestaurantRepository.class)


### PR DESCRIPTION
## 💻 작업 내역

### ✓ 인증

- 인증이 필요한 API 요청에 대해 Header에 전달된 액세스 토큰을 이용하여 자격 증명을 진행합니다.

#### 💡 아이디어

- `InterceptorRegistry`에 인증을 수행하기 위해 정의한 `HandlerInterceptor` 구현체 `AuthenticationInterceptor`를 추가합니다.
- 모든 API 요청은 Controller 매핑 전, `AuthenticationInterceptor` 내 구현 메서드인 `preHandle()`을 수행합니다.

#### 📋 비즈니스 로직

- 인증을 수행하지 않는 API 요청의 경우 통과합니다.
  - `RequestUnauthenticated` `enum`에 대상 API 요청 메서드, 경로 정보를 갖는 인스턴스를 정의했습니다.
- 다음의 경우 예외처리합니다.
  - Header에 Authorization을 포함하지 않은 경우
  - Authorization이 `'Bearer '`로 시작하지 않는 경우
  - 액세스 토큰이 정상적인 형식이 아닌 경우
  - 액세스 토큰 디코딩에 실패한 경우
  - 액세스 토큰이 만료된 경우
- Authorization에서 파싱해 획득한 액세스 토큰을 디코딩해 `userId`를 얻습니다.
- RequestAttribute에 `userId`를 전달합니다.

## 🔎 PR 특이 사항

- `AuthenticationInterceptor`에서 인가를 수행하지는 않으며, 인증된 사용자의 식별자만을 전달합니다.

### 모든 API 요청 호출 시

- 로그인을 통해 획득한 액세스 토큰을 다음과 같이 헤더에 Key, Value 쌍으로 포함시켜 전달해주셔야 합니다.

```text
// Key: 'Authorization'
// Value: 'Bearer ACCESS_TOKEN'

Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSG9uZyBDaGFuZ2kifQ.xpyvPN2CyddE07unm9eBOktdq3gZTqiKZJ1VPiAxI3g
```