### PR TITLE
✨ Feature: 액세스 토큰 재발행

### DIFF
--- a/src/main/java/com/wanted/babdoduk/common/exception/ErrorType.java
+++ b/src/main/java/com/wanted/babdoduk/common/exception/ErrorType.java
@@ -1,6 +1,10 @@
 package com.wanted.babdoduk.common.exception;
 
 import com.wanted.babdoduk.session.exception.PasswordMismatchedException;
+import com.wanted.babdoduk.session.exception.RefreshTokenDifferentException;
+import com.wanted.babdoduk.session.exception.RefreshTokenExpiredException;
+import com.wanted.babdoduk.session.exception.RefreshTokenNotIssuedException;
+import com.wanted.babdoduk.session.exception.TokenDecodingFailedException;
 import com.wanted.babdoduk.session.exception.TokenIssuanceFailedException;
 import com.wanted.babdoduk.restaurant.domain.review.exception.ReviewNotFoundException;
 import com.wanted.babdoduk.sigungu.exception.FailedGetSiGunGuException;
@@ -24,7 +28,12 @@ public enum ErrorType {
     U003("U003", "존재하지 않는 사용자입니다.", UserNotFoundException.class, HttpStatus.NOT_FOUND),
 
     SE001("SE001", "비밀번호가 일치하지 않습니다.", PasswordMismatchedException.class, HttpStatus.BAD_REQUEST),
-    SE002("SE002", "토큰 생성에 실패했습니다.", TokenIssuanceFailedException.class, HttpStatus.INTERNAL_SERVER_ERROR),
+
+    T001("T001", "토큰 생성에 실패했습니다.", TokenIssuanceFailedException.class, HttpStatus.INTERNAL_SERVER_ERROR),
+    T002("T002", "토큰 디코딩에 실패했습니다.", TokenDecodingFailedException.class, HttpStatus.INTERNAL_SERVER_ERROR),
+    T003("T003", "발행된 리프레시 토큰이 없습니다.", RefreshTokenNotIssuedException.class, HttpStatus.UNAUTHORIZED),
+    T004("T004", "발행된 리프레시 토큰과 다릅니다.", RefreshTokenDifferentException.class, HttpStatus.UNAUTHORIZED),
+    T005("T005", "리프레시 토큰이 만료되었습니다.", RefreshTokenExpiredException.class, HttpStatus.UNAUTHORIZED),
 
     S001("S001", "시도, 시군구 목록을 불러올 수 없습니다.", FailedGetSiGunGuException.class, HttpStatus.INTERNAL_SERVER_ERROR),
     R001("R001", "식당이 존재하지 않습니다.", NotFoundRestaurantException.class, HttpStatus.NOT_FOUND),

--- a/src/main/java/com/wanted/babdoduk/common/util/JwtUtil.java
+++ b/src/main/java/com/wanted/babdoduk/common/util/JwtUtil.java
@@ -4,11 +4,14 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class JwtUtil {
+
+    private static final String CLAIM_USER_ID = "userId";
 
     private final Algorithm algorithm;
     private final Long validTimeAccessToken;
@@ -32,6 +35,14 @@ public class JwtUtil {
                 .withClaim("userId", userId)
                 .withExpiresAt(expirationDateRefreshToken)
                 .sign(algorithm);
+    }
+
+    public Long decodeRefreshToken(String token) {
+        JWTVerifier verifier = JWT.require(algorithm)
+                .build();
+        DecodedJWT verified = verifier.verify(token);
+        return verified.getClaim(CLAIM_USER_ID)
+                .asLong();
     }
 
     public boolean isTokenExpired(String token) {

--- a/src/main/java/com/wanted/babdoduk/session/controller/AccessTokenController.java
+++ b/src/main/java/com/wanted/babdoduk/session/controller/AccessTokenController.java
@@ -1,0 +1,35 @@
+package com.wanted.babdoduk.session.controller;
+
+import com.wanted.babdoduk.common.response.ApiResponse;
+import com.wanted.babdoduk.session.dto.AccessTokenReissuanceRequestDto;
+import com.wanted.babdoduk.session.dto.AccessTokenReissuanceResponseDto;
+import com.wanted.babdoduk.session.service.ReissueAccessTokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "세션")
+@RestController
+@RequestMapping("/api/v1/access-tokens")
+@RequiredArgsConstructor
+public class AccessTokenController {
+
+    private final ReissueAccessTokenService reissueAccessTokenService;
+
+    @Operation(summary = "액세스 토큰 재발행")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<AccessTokenReissuanceResponseDto> reissue(
+            @Valid @RequestBody AccessTokenReissuanceRequestDto accessTokenReissuanceRequestDto
+    ) {
+        return ApiResponse.created(reissueAccessTokenService
+                .reissueAccessToken(accessTokenReissuanceRequestDto));
+    }
+}

--- a/src/main/java/com/wanted/babdoduk/session/domain/entity/UserRefreshToken.java
+++ b/src/main/java/com/wanted/babdoduk/session/domain/entity/UserRefreshToken.java
@@ -2,6 +2,7 @@ package com.wanted.babdoduk.session.domain.entity;
 
 import com.wanted.babdoduk.common.util.JwtUtil;
 import com.wanted.babdoduk.user.domain.entity.User;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
@@ -19,6 +20,7 @@ public class UserRefreshToken {
     @Id
     private Long userId;
 
+    @Column(name = "value")
     private String value;
 
     @UpdateTimestamp
@@ -34,6 +36,14 @@ public class UserRefreshToken {
         return value;
     }
 
+    public boolean isNotIssued() {
+        return value == null;
+    }
+
+    public boolean isNotSameAs(String refreshToken) {
+        return !value.equals(refreshToken);
+    }
+
     public boolean isExpired(JwtUtil jwtUtil) {
         if (value == null) {
             return true;
@@ -43,5 +53,9 @@ public class UserRefreshToken {
 
     public void reissue(JwtUtil jwtUtil) {
         value = jwtUtil.issueRefreshToken(userId);
+    }
+
+    public void expire() {
+        value = null;
     }
 }

--- a/src/main/java/com/wanted/babdoduk/session/domain/entity/UserRefreshToken.java
+++ b/src/main/java/com/wanted/babdoduk/session/domain/entity/UserRefreshToken.java
@@ -45,13 +45,10 @@ public class UserRefreshToken {
     }
 
     public boolean isExpired(JwtUtil jwtUtil) {
-        if (value == null) {
-            return true;
-        }
         return jwtUtil.isTokenExpired(value);
     }
 
-    public void reissue(JwtUtil jwtUtil) {
+    public void issue(JwtUtil jwtUtil) {
         value = jwtUtil.issueRefreshToken(userId);
     }
 

--- a/src/main/java/com/wanted/babdoduk/session/dto/AccessTokenReissuanceRequestDto.java
+++ b/src/main/java/com/wanted/babdoduk/session/dto/AccessTokenReissuanceRequestDto.java
@@ -1,0 +1,19 @@
+package com.wanted.babdoduk.session.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+@Getter
+public class AccessTokenReissuanceRequestDto {
+    @Schema(title = "Refresh Token", description = "리프레시 토큰")
+    @NotBlank
+    private String refreshToken;
+}

--- a/src/main/java/com/wanted/babdoduk/session/dto/AccessTokenReissuanceResponseDto.java
+++ b/src/main/java/com/wanted/babdoduk/session/dto/AccessTokenReissuanceResponseDto.java
@@ -1,0 +1,10 @@
+package com.wanted.babdoduk.session.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AccessTokenReissuanceResponseDto(
+        String accessToken
+) {
+
+}

--- a/src/main/java/com/wanted/babdoduk/session/exception/RefreshTokenDifferentException.java
+++ b/src/main/java/com/wanted/babdoduk/session/exception/RefreshTokenDifferentException.java
@@ -1,0 +1,7 @@
+package com.wanted.babdoduk.session.exception;
+
+import com.wanted.babdoduk.common.exception.WantedException;
+
+public class RefreshTokenDifferentException extends WantedException {
+
+}

--- a/src/main/java/com/wanted/babdoduk/session/exception/RefreshTokenExpiredException.java
+++ b/src/main/java/com/wanted/babdoduk/session/exception/RefreshTokenExpiredException.java
@@ -1,0 +1,7 @@
+package com.wanted.babdoduk.session.exception;
+
+import com.wanted.babdoduk.common.exception.WantedException;
+
+public class RefreshTokenExpiredException extends WantedException {
+
+}

--- a/src/main/java/com/wanted/babdoduk/session/exception/RefreshTokenNotIssuedException.java
+++ b/src/main/java/com/wanted/babdoduk/session/exception/RefreshTokenNotIssuedException.java
@@ -1,0 +1,7 @@
+package com.wanted.babdoduk.session.exception;
+
+import com.wanted.babdoduk.common.exception.WantedException;
+
+public class RefreshTokenNotIssuedException extends WantedException {
+
+}

--- a/src/main/java/com/wanted/babdoduk/session/exception/TokenDecodingFailedException.java
+++ b/src/main/java/com/wanted/babdoduk/session/exception/TokenDecodingFailedException.java
@@ -1,0 +1,7 @@
+package com.wanted.babdoduk.session.exception;
+
+import com.wanted.babdoduk.common.exception.WantedException;
+
+public class TokenDecodingFailedException extends WantedException {
+
+}

--- a/src/main/java/com/wanted/babdoduk/session/service/LoginService.java
+++ b/src/main/java/com/wanted/babdoduk/session/service/LoginService.java
@@ -39,8 +39,8 @@ public class LoginService {
                 .findByUserId(user.id());
 
         try {
-            if (userRefreshToken.isExpired(jwtUtil)) {
-                userRefreshToken.reissue(jwtUtil);
+            if (userRefreshToken.isNotIssued() || userRefreshToken.isExpired(jwtUtil)) {
+                userRefreshToken.issue(jwtUtil);
             }
 
             String accessToken = jwtUtil.issueAccessToken(user.id());

--- a/src/main/java/com/wanted/babdoduk/session/service/ReissueAccessTokenService.java
+++ b/src/main/java/com/wanted/babdoduk/session/service/ReissueAccessTokenService.java
@@ -1,17 +1,59 @@
 package com.wanted.babdoduk.session.service;
 
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.wanted.babdoduk.common.util.JwtUtil;
+import com.wanted.babdoduk.session.domain.entity.UserRefreshToken;
+import com.wanted.babdoduk.session.domain.repository.UserRefreshTokenRepository;
 import com.wanted.babdoduk.session.dto.AccessTokenReissuanceRequestDto;
 import com.wanted.babdoduk.session.dto.AccessTokenReissuanceResponseDto;
+import com.wanted.babdoduk.session.exception.RefreshTokenDifferentException;
+import com.wanted.babdoduk.session.exception.RefreshTokenNotIssuedException;
+import com.wanted.babdoduk.session.exception.TokenDecodingFailedException;
+import com.wanted.babdoduk.session.exception.RefreshTokenExpiredException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@RequiredArgsConstructor
 public class ReissueAccessTokenService {
 
+    private final UserRefreshTokenRepository userRefreshTokenRepository;
+    private final JwtUtil jwtUtil;
+
+    @Transactional(noRollbackFor = RefreshTokenDifferentException.class)
     public AccessTokenReissuanceResponseDto reissueAccessToken(
             AccessTokenReissuanceRequestDto accessTokenReissuanceRequestDto
     ) {
-        return null;
+        String refreshToken = accessTokenReissuanceRequestDto.getRefreshToken();
+
+        try {
+            Long userId = jwtUtil.decodeRefreshToken(refreshToken);
+
+            UserRefreshToken userRefreshToken = userRefreshTokenRepository
+                    .findByUserId(userId);
+
+            if (userRefreshToken.isNotIssued()) {
+                throw new RefreshTokenNotIssuedException();
+            }
+
+            if (userRefreshToken.isNotSameAs(refreshToken)) {
+                userRefreshToken.expire();
+                throw new RefreshTokenDifferentException();
+            }
+
+            String accessToken = jwtUtil.issueAccessToken(userId);
+
+            return AccessTokenReissuanceResponseDto.builder()
+                    .accessToken(accessToken)
+                    .build();
+
+        } catch (JWTDecodeException exception) {
+            throw new TokenDecodingFailedException();
+
+        } catch (TokenExpiredException exception) {
+            throw new RefreshTokenExpiredException();
+        }
     }
 }

--- a/src/main/java/com/wanted/babdoduk/session/service/ReissueAccessTokenService.java
+++ b/src/main/java/com/wanted/babdoduk/session/service/ReissueAccessTokenService.java
@@ -1,0 +1,17 @@
+package com.wanted.babdoduk.session.service;
+
+import com.wanted.babdoduk.session.dto.AccessTokenReissuanceRequestDto;
+import com.wanted.babdoduk.session.dto.AccessTokenReissuanceResponseDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ReissueAccessTokenService {
+
+    public AccessTokenReissuanceResponseDto reissueAccessToken(
+            AccessTokenReissuanceRequestDto accessTokenReissuanceRequestDto
+    ) {
+        return null;
+    }
+}

--- a/src/test/java/com/wanted/babdoduk/session/controller/AccessTokenControllerTest.java
+++ b/src/test/java/com/wanted/babdoduk/session/controller/AccessTokenControllerTest.java
@@ -1,0 +1,84 @@
+package com.wanted.babdoduk.session.controller;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wanted.babdoduk.batch.client.RawRestaurantRepository;
+import com.wanted.babdoduk.batch.service.OpenRestaurantService;
+import com.wanted.babdoduk.session.dto.AccessTokenReissuanceRequestDto;
+import com.wanted.babdoduk.session.dto.AccessTokenReissuanceResponseDto;
+import com.wanted.babdoduk.session.service.ReissueAccessTokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AccessTokenController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@MockBean(OpenRestaurantService.class)
+@MockBean(RawRestaurantRepository.class)
+class AccessTokenControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReissueAccessTokenService reissueAccessTokenService;
+
+    @DisplayName("POST /api/v1/access-tokens")
+    @Nested
+    class PostAccessTokens {
+
+        private static final String ACCESS_TOKEN = "ACCESS_TOKEN";
+
+        @DisplayName("성공: 재발행된 Access Token 반환")
+        @Test
+        void success() throws Exception {
+            AccessTokenReissuanceResponseDto accessTokenReissuanceResponseDto
+                    = AccessTokenReissuanceResponseDto.builder()
+                    .accessToken(ACCESS_TOKEN)
+                    .build();
+
+            given(reissueAccessTokenService
+                    .reissueAccessToken(any(AccessTokenReissuanceRequestDto.class)))
+                    .willReturn(accessTokenReissuanceResponseDto);
+
+            mockMvc.perform(post("/api/v1/access-tokens")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "refreshToken": "REFRESH_TOKEN"
+                                    }"""))
+                    .andExpect(status().isCreated());
+
+            verify(reissueAccessTokenService)
+                    .reissueAccessToken(any(AccessTokenReissuanceRequestDto.class));
+        }
+
+        @DisplayName("실패: refreshToken 입력하지 않은 경우 예외 응답 반환")
+        @Test
+        void blankRefreshToken() throws Exception {
+            mockMvc.perform(post("/api/v1/access-tokens")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString("refreshToken")));
+
+            verify(reissueAccessTokenService, never())
+                    .reissueAccessToken(any(AccessTokenReissuanceRequestDto.class));
+        }
+    }
+}

--- a/src/test/java/com/wanted/babdoduk/session/service/LoginServiceTest.java
+++ b/src/test/java/com/wanted/babdoduk/session/service/LoginServiceTest.java
@@ -101,7 +101,7 @@ class LoginServiceTest {
             assertThat(loginResultDto.accessToken()).isNotNull();
             assertThat(loginResultDto.refreshToken()).isEqualTo(refreshToken);
 
-            verify(userRefreshToken, never()).reissue(jwtUtil);
+            verify(userRefreshToken, never()).issue(jwtUtil);
             verify(jwtUtil).issueAccessToken(USER_ID);
         }
 
@@ -121,7 +121,7 @@ class LoginServiceTest {
             assertThat(loginResultDto.accessToken()).isNotNull();
             assertThat(loginResultDto.refreshToken()).isNotNull();
 
-            verify(userRefreshToken).reissue(jwtUtil);
+            verify(userRefreshToken).issue(jwtUtil);
             verify(jwtUtil).issueAccessToken(USER_ID);
         }
 
@@ -146,7 +146,7 @@ class LoginServiceTest {
             assertThat(loginResultDto.refreshToken()).isNotNull();
             assertThat(loginResultDto.refreshToken()).isNotEqualTo(refreshToken);
 
-            verify(userRefreshToken).reissue(jwtUtil);
+            verify(userRefreshToken).issue(jwtUtil);
             verify(jwtUtil).issueAccessToken(USER_ID);
         }
     }

--- a/src/test/java/com/wanted/babdoduk/session/service/ReissueAccessTokenServiceTest.java
+++ b/src/test/java/com/wanted/babdoduk/session/service/ReissueAccessTokenServiceTest.java
@@ -1,0 +1,116 @@
+package com.wanted.babdoduk.session.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.auth0.jwt.algorithms.Algorithm;
+import com.wanted.babdoduk.common.util.JwtUtil;
+import com.wanted.babdoduk.session.domain.entity.UserRefreshToken;
+import com.wanted.babdoduk.session.domain.repository.UserRefreshTokenRepository;
+import com.wanted.babdoduk.session.dto.AccessTokenReissuanceRequestDto;
+import com.wanted.babdoduk.session.dto.AccessTokenReissuanceResponseDto;
+import com.wanted.babdoduk.session.exception.RefreshTokenExpiredException;
+import com.wanted.babdoduk.session.exception.RefreshTokenNotIssuedException;
+import com.wanted.babdoduk.user.domain.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReissueAccessTokenServiceTest {
+
+    @InjectMocks
+    private ReissueAccessTokenService reissueAccessTokenService;
+
+    @Mock
+    private UserRefreshTokenRepository userRefreshTokenRepository;
+
+    private static final String JWT_SECRET = "SECRET";
+    private static final Long VALID_TIME_ACCESS_TOKEN = 1000L;
+    private static final Long VALID_TIME_REFRESH_TOKEN = 3000L;
+
+    @Spy
+    private JwtUtil jwtUtil = new JwtUtil(
+            Algorithm.HMAC256(JWT_SECRET),
+            VALID_TIME_ACCESS_TOKEN,
+            VALID_TIME_REFRESH_TOKEN
+    );
+
+    private static final Long USER_ID = 2277L;
+
+    private final User user = User.builder()
+            .id(USER_ID)
+            .build();
+
+    @DisplayName("성공: 예외처리 없이 액세스 토큰 재발행")
+    @Test
+    void success() {
+        String refreshToken = jwtUtil.issueRefreshToken(USER_ID);
+        UserRefreshToken userRefreshToken = UserRefreshToken.builder()
+                .user(user)
+                .value(refreshToken)
+                .build();
+
+        given(userRefreshTokenRepository.findByUserId(USER_ID))
+                .willReturn(userRefreshToken);
+
+        AccessTokenReissuanceRequestDto accessTokenReissuanceRequestDto
+                = AccessTokenReissuanceRequestDto.builder()
+                .refreshToken(refreshToken)
+                .build();
+
+        AccessTokenReissuanceResponseDto accessTokenReissuanceResponseDto
+                = reissueAccessTokenService.reissueAccessToken(accessTokenReissuanceRequestDto);
+
+        assertThat(accessTokenReissuanceResponseDto.accessToken()).isNotNull();
+    }
+
+    @DisplayName("실패: 발행된 리프레시 토큰이 없었던 경우 예외 발생")
+    @Test
+    void refreshTokenNotIssued() {
+        UserRefreshToken userRefreshToken = UserRefreshToken.builder()
+                .user(user)
+                .value(null)
+                .build();
+
+        given(userRefreshTokenRepository.findByUserId(USER_ID))
+                .willReturn(userRefreshToken);
+
+        String refreshToken = jwtUtil.issueRefreshToken(USER_ID);
+        AccessTokenReissuanceRequestDto accessTokenReissuanceRequestDto
+                = AccessTokenReissuanceRequestDto.builder()
+                .refreshToken(refreshToken)
+                .build();
+
+        assertThrows(RefreshTokenNotIssuedException.class, () -> reissueAccessTokenService
+                .reissueAccessToken(accessTokenReissuanceRequestDto));
+
+        verify(jwtUtil, never()).issueAccessToken(USER_ID);
+    }
+
+    @DisplayName("실패: 발행된 리프레시 토큰이 만료된 경우 예외 발생")
+    @Test
+    void refreshTokenDifferent() {
+        String refreshToken = jwtUtil.issueRefreshToken(USER_ID);
+        AccessTokenReissuanceRequestDto accessTokenReissuanceRequestDto
+                = AccessTokenReissuanceRequestDto.builder()
+                .refreshToken(refreshToken)
+                .build();
+
+        assertThrows(RefreshTokenExpiredException.class, () -> {
+            Thread.sleep(VALID_TIME_REFRESH_TOKEN);
+            reissueAccessTokenService.reissueAccessToken(accessTokenReissuanceRequestDto);
+        });
+
+        verify(userRefreshTokenRepository, never()).findByUserId(any(Long.class));
+        verify(jwtUtil, never()).issueAccessToken(USER_ID);
+    }
+}


### PR DESCRIPTION
## 💻 작업 내역

### ✓ 액세스 토큰 재발행

- Access Token이 만료된 사용자가 Refresh Token을 이용하여 Access Token의 재발행을 요청하는 API입니다. 

#### 💡 아이디어

- Access Token이 만료된 경우 서버는 401 응답과 함께 액세스 토큰이 만료되었다는 응답을 송신합니다. 클라이언트가 해당 응답을 인지했을 때, 본 API 요청을 보내 유효한 액세스 토큰을 재발행하는 방식을 고려했습니다.

#### 📋 비즈니스 로직

- 전달된 리프레시 토큰으로부터 사용자 식별자를 획득합니다.
  - 이 과정에서 토큰이 잘못되었거나 만료되었을 경우 예외처리합니다.
- 식별한 사용자에 대해 영속화되어 있던 `UserRefreshToken` Entity를 쿼리합니다.
  - 영속화되어 있던 리프레시 토큰이 없거나, 전달된 토큰과 서로 다를 경우 예외처리합니다.
  - 서로 다른 경우에는 추가적으로 기존에 발행되었던 리프레시 토큰을 만료 처리합니다.
- 발행되었던 리프레시 토큰과 전달된 리프레시 토큰이 같을 경우, 액세스 토큰을 새로 생성해 응답으로 반환합니다.

## 🔎 PR 특이 사항

### TODO

- `RequestUnauthenticated`에 본 API 추가