### PR TITLE
✨ Feature: 맛집 알림 - 유저 개별 전송, 맛집 추천 querydsl 작성

### DIFF
--- a/src/main/java/com/wanted/babdoduk/BabDodukApplication.java
+++ b/src/main/java/com/wanted/babdoduk/BabDodukApplication.java
@@ -8,10 +8,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableFeignClients
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableAsync
 public class BabDodukApplication implements CommandLineRunner {
 
     public static final int INIT_SIZE = 0;

--- a/src/main/java/com/wanted/babdoduk/infrastructure/webhook/client/DiscordWebhookClient.java
+++ b/src/main/java/com/wanted/babdoduk/infrastructure/webhook/client/DiscordWebhookClient.java
@@ -13,6 +13,7 @@ import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConsta
 import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.FIELDS;
 import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.ICON_URL;
 import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.NAME;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.NOT_FOUND_RESTAURANT_DESCRIPTION;
 import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.SEND_SUCCESS_LOG;
 import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.USERNAME;
 import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.VALUE;
@@ -57,7 +58,7 @@ public class DiscordWebhookClient implements WebhookClient {
         List<Map<String, Object>> fields = new ArrayList<>();
 
         embed.put(AUTHOR, createAuthorMap());
-        embed.put(DESCRIPTION, DEFAULT_DESCRIPTION);
+        embed.put(DESCRIPTION, createDescription(restaurants.size()));
 
         for (Restaurant restaurant : restaurants) {
             fields.add(createFieldMap(restaurant));
@@ -66,6 +67,13 @@ public class DiscordWebhookClient implements WebhookClient {
         embed.put(FIELDS, fields);
         embeds.add(embed);
         return embeds;
+    }
+
+    private String createDescription(int restaurantListSize) {
+        if (restaurantListSize == 0) {
+            return NOT_FOUND_RESTAURANT_DESCRIPTION;
+        }
+        return DEFAULT_DESCRIPTION;
     }
 
     private Map<String, Object> createAuthorMap() {

--- a/src/main/java/com/wanted/babdoduk/infrastructure/webhook/client/DiscordWebhookClient.java
+++ b/src/main/java/com/wanted/babdoduk/infrastructure/webhook/client/DiscordWebhookClient.java
@@ -108,7 +108,7 @@ public class DiscordWebhookClient implements WebhookClient {
             .bodyValue(bodyMap)
             .retrieve()
             .bodyToMono(String.class)
-            .block();
+            .subscribe();
     }
 
 }

--- a/src/main/java/com/wanted/babdoduk/infrastructure/webhook/client/DiscordWebhookClient.java
+++ b/src/main/java/com/wanted/babdoduk/infrastructure/webhook/client/DiscordWebhookClient.java
@@ -1,6 +1,21 @@
 package com.wanted.babdoduk.infrastructure.webhook.client;
 
-import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.*;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.AUTHOR;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.AVATAR_URL;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.CONTENT;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.DEFAULT_AVATAR_URL;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.DEFAULT_CONTENT;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.DEFAULT_DESCRIPTION;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.DEFAULT_TITLE;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.DEFAULT_USERNAME;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.DESCRIPTION;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.EMBEDS;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.FIELDS;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.ICON_URL;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.NAME;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.SEND_SUCCESS_LOG;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.USERNAME;
+import static com.wanted.babdoduk.infrastructure.webhook.constants.WebhookConstants.VALUE;
 
 import com.wanted.babdoduk.restaurant.domain.restaurant.entity.Restaurant;
 import java.util.ArrayList;
@@ -8,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -16,15 +30,12 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Slf4j
 public class DiscordWebhookClient implements WebhookClient {
 
-    @Value("${webhook.api.url}")
-    private String discordWebhookUrl;
-
     @Override
-    public void sendRestaurantNoticeMessage(List<Restaurant> restaurants) {
+    public void sendRestaurantNoticeMessage(String webhookUrl, List<Restaurant> restaurants) {
         Map<String, Object> discordMessageBodyMap = createDiscordMessage(restaurants);
 
         WebClient baseWebClient = getBaseWebClient();
-        postRequest(discordMessageBodyMap, baseWebClient);
+        postRequest(webhookUrl, discordMessageBodyMap, baseWebClient);
         log.info(SEND_SUCCESS_LOG);
     }
 
@@ -81,11 +92,11 @@ public class DiscordWebhookClient implements WebhookClient {
             .build();
     }
 
-    private <T> void postRequest(Map<String, Object> bodyMap,
+    private <T> void postRequest(String webhookUrl, Map<String, Object> bodyMap,
         WebClient webClient) {
         webClient
             .post()
-            .uri(discordWebhookUrl)
+            .uri(webhookUrl)
             .bodyValue(bodyMap)
             .retrieve()
             .bodyToMono(String.class)

--- a/src/main/java/com/wanted/babdoduk/infrastructure/webhook/client/WebhookClient.java
+++ b/src/main/java/com/wanted/babdoduk/infrastructure/webhook/client/WebhookClient.java
@@ -5,6 +5,6 @@ import java.util.List;
 
 public interface WebhookClient {
 
-    void sendRestaurantNoticeMessage(List<Restaurant> restaurants);
+    void sendRestaurantNoticeMessage(String webhookUrl, List<Restaurant> restaurants);
 
 }

--- a/src/main/java/com/wanted/babdoduk/infrastructure/webhook/constants/WebhookConstants.java
+++ b/src/main/java/com/wanted/babdoduk/infrastructure/webhook/constants/WebhookConstants.java
@@ -15,6 +15,7 @@ public class WebhookConstants {
     public static final String ICON_URL = "icon_url";
     public static final String DESCRIPTION = "description";
     public static final String DEFAULT_DESCRIPTION = "가장 가까운 맛집을 구해 봤어요!";
+    public static final String NOT_FOUND_RESTAURANT_DESCRIPTION = "근처 맛집이 없습니다 ㅠㅠ";
     public static final String VALUE = "value";
     public static final String FIELDS = "fields";
     public static final String SEND_SUCCESS_LOG = "[info] 점심 추천 알림 메세지가 발송되었습니다.";

--- a/src/main/java/com/wanted/babdoduk/restaurant/domain/restaurant/repository/RestaurantRepositoryCustom.java
+++ b/src/main/java/com/wanted/babdoduk/restaurant/domain/restaurant/repository/RestaurantRepositoryCustom.java
@@ -1,11 +1,16 @@
 package com.wanted.babdoduk.restaurant.domain.restaurant.repository;
 
+import com.wanted.babdoduk.restaurant.domain.restaurant.entity.Restaurant;
 import com.wanted.babdoduk.restaurant.dto.RestaurantListResponseDto;
 import com.wanted.babdoduk.restaurant.dto.RestaurantSearchRequestDto;
+import com.wanted.babdoduk.user.domain.entity.User;
+import java.util.List;
 import org.springframework.data.domain.Page;
 
 public interface RestaurantRepositoryCustom {
 
     Page<RestaurantListResponseDto> findBySearch(RestaurantSearchRequestDto request);
+
+    List<Restaurant> findRecommendedRestaurants(User user);
 
 }

--- a/src/main/java/com/wanted/babdoduk/restaurant/domain/restaurant/repository/RestaurantRepositoryImpl.java
+++ b/src/main/java/com/wanted/babdoduk/restaurant/domain/restaurant/repository/RestaurantRepositoryImpl.java
@@ -16,6 +16,7 @@ import com.wanted.babdoduk.restaurant.domain.restaurant.entity.Restaurant;
 import com.wanted.babdoduk.restaurant.domain.restaurant.enums.BusinessStatus;
 import com.wanted.babdoduk.restaurant.dto.RestaurantListResponseDto;
 import com.wanted.babdoduk.restaurant.dto.RestaurantSearchRequestDto;
+import com.wanted.babdoduk.user.domain.entity.User;
 import java.math.BigDecimal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -70,6 +71,15 @@ public class RestaurantRepositoryImpl implements RestaurantRepositoryCustom {
                        keywordCt(condition.getKeyword()));
 
         return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetch().size());
+    }
+
+    @Override
+    public List<Restaurant> findRecommendedRestaurants(User user) {
+        return jpaQueryFactory.selectFrom(restaurant)
+            .where(closedEq())
+            .orderBy(getDistance(user.getLatitude(), user.getLongitude()).asc())
+            .limit(5)
+            .fetch();
     }
 
     private BooleanExpression keywordCt(String keyword) {

--- a/src/main/java/com/wanted/babdoduk/restaurant/domain/restaurant/repository/RestaurantRepositoryImpl.java
+++ b/src/main/java/com/wanted/babdoduk/restaurant/domain/restaurant/repository/RestaurantRepositoryImpl.java
@@ -76,7 +76,9 @@ public class RestaurantRepositoryImpl implements RestaurantRepositoryCustom {
     @Override
     public List<Restaurant> findRecommendedRestaurants(User user) {
         return jpaQueryFactory.selectFrom(restaurant)
-            .where(closedEq())
+            .leftJoin(restaurantReviewStat)
+            .on(restaurant.id.eq(restaurantReviewStat.restaurantId))
+            .where(closedEq(), reviewScoreBetweenFourAndFive())
             .orderBy(getDistance(user.getLatitude(), user.getLongitude()).asc())
             .limit(5)
             .fetch();
@@ -93,6 +95,10 @@ public class RestaurantRepositoryImpl implements RestaurantRepositoryCustom {
 
     private BooleanExpression closedEq() {
         return restaurant.bizStatus.eq(BusinessStatus.Open.status);
+    }
+
+    private BooleanExpression reviewScoreBetweenFourAndFive() {
+        return restaurantReviewStat.averageScore.between(4, 5);
     }
 
     private BooleanExpression distanceLoe(String latitude, String longitude, double range) {

--- a/src/main/java/com/wanted/babdoduk/user/domain/entity/User.java
+++ b/src/main/java/com/wanted/babdoduk/user/domain/entity/User.java
@@ -70,4 +70,13 @@ public class User extends BaseTimeEntity {
                 .userId(id)
                 .build();
     }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+
 }

--- a/src/main/java/com/wanted/babdoduk/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/wanted/babdoduk/user/domain/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.wanted.babdoduk.user.domain.repository;
 
 import com.wanted.babdoduk.user.domain.entity.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
 
     Optional<User> findByUsername(String username);
+
+    List<User> findUsersByLunchPushApprovedIsTrue();
+
 }

--- a/src/test/java/com/wanted/babdoduk/infrastructure/webhook/client/DiscordWebhookClientTest.java
+++ b/src/test/java/com/wanted/babdoduk/infrastructure/webhook/client/DiscordWebhookClientTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class DiscordWebhookClientTest {
@@ -39,14 +38,12 @@ class DiscordWebhookClientTest {
     @DisplayName("디스코드 웹훅 메세지 POST 전송 - 성공")
     @Test
     public void send_discord_webhook_message_success() {
-        // given
-        ReflectionTestUtils.setField(discordWebhookClient, "discordWebhookUrl", WEBHOOK_TEST_URL);
-
         // when
-        discordWebhookClient.sendRestaurantNoticeMessage(restaurants);
+        discordWebhookClient.sendRestaurantNoticeMessage(WEBHOOK_TEST_URL, restaurants);
 
         // then
-        assertDoesNotThrow(() -> discordWebhookClient.sendRestaurantNoticeMessage(restaurants));
+        assertDoesNotThrow(
+            () -> discordWebhookClient.sendRestaurantNoticeMessage(WEBHOOK_TEST_URL, restaurants));
     }
 
 }

--- a/src/test/java/com/wanted/babdoduk/restaurant/domain/restaurant/repository/RestaurantRepositoryImplTest.java
+++ b/src/test/java/com/wanted/babdoduk/restaurant/domain/restaurant/repository/RestaurantRepositoryImplTest.java
@@ -68,7 +68,7 @@ class RestaurantRepositoryImplTest {
 
         stat1 = RestaurantReviewStat.builder()
             .restaurantId(restaurant1.getId())
-            .averageScore(4.33)
+            .averageScore(4.73)
             .reviewCount(3)
             .build();
 
@@ -91,7 +91,7 @@ class RestaurantRepositoryImplTest {
 
         stat2 = RestaurantReviewStat.builder()
             .restaurantId(restaurant2.getId())
-            .averageScore(3.51)
+            .averageScore(4.51)
             .reviewCount(2)
             .build();
 
@@ -174,7 +174,7 @@ class RestaurantRepositoryImplTest {
         assertThat(result.getContent().get(1).getCuisineType()).isEqualTo(KOREAN_FOOD);
     }
 
-    @DisplayName("레스토랑 거리순 추천 조회 성공")
+    @DisplayName("레스토랑 추천 조회 성공")
     @Test
     void get_restaurant_recommended_list_success() {
         List<Restaurant> result = restaurantRepository.findRecommendedRestaurants(user);

--- a/src/test/java/com/wanted/babdoduk/restaurant/domain/restaurant/repository/RestaurantRepositoryImplTest.java
+++ b/src/test/java/com/wanted/babdoduk/restaurant/domain/restaurant/repository/RestaurantRepositoryImplTest.java
@@ -2,7 +2,6 @@ package com.wanted.babdoduk.restaurant.domain.restaurant.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.wanted.babdoduk.batch.client.RawRestaurantRepository;
 import com.wanted.babdoduk.batch.service.OpenRestaurantService;
 import com.wanted.babdoduk.common.config.querydsl.QueryDslConfig;
 import com.wanted.babdoduk.restaurant.domain.restaurant.entity.Restaurant;
@@ -10,9 +9,11 @@ import com.wanted.babdoduk.restaurant.domain.restaurant.enums.SortType;
 import com.wanted.babdoduk.restaurant.domain.review.entity.RestaurantReviewStat;
 import com.wanted.babdoduk.restaurant.dto.RestaurantListResponseDto;
 import com.wanted.babdoduk.restaurant.dto.RestaurantSearchRequestDto;
+import com.wanted.babdoduk.user.domain.entity.User;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.math.BigDecimal;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,52 +47,59 @@ class RestaurantRepositoryImplTest {
 
     Restaurant restaurant1, restaurant2;
     RestaurantReviewStat stat1, stat2;
+    User user;
 
     @BeforeEach
     void setUp() {
         restaurant1 = Restaurant.builder()
-                                .manageNo("manage-no")
-                                .sigunName("sigun name 1")
-                                .sigunCode("sigun code 1")
-                                .bizName("biz name 1")
-                                .bizStatus("영업/정상")
-                                .cuisineType("중국식")
-                                .roadAddr("road address")
-                                .jibunAddr("jibun address")
-                                .latitude(new BigDecimal("37.403581"))
-                                .longitude(new BigDecimal("126.946761"))
-                                .build();
+            .manageNo("manage-no")
+            .sigunName("sigun name 1")
+            .sigunCode("sigun code 1")
+            .bizName("biz name 1")
+            .bizStatus("영업/정상")
+            .cuisineType("중국식")
+            .roadAddr("road address")
+            .jibunAddr("jibun address")
+            .latitude(new BigDecimal("38.403581"))
+            .longitude(new BigDecimal("126.946761"))
+            .build();
 
         entityManager.persist(restaurant1);
 
         stat1 = RestaurantReviewStat.builder()
-                                    .restaurantId(restaurant1.getId())
-                                    .averageScore(4.33)
-                                    .reviewCount(3)
-                                    .build();
+            .restaurantId(restaurant1.getId())
+            .averageScore(4.33)
+            .reviewCount(3)
+            .build();
 
         entityManager.persist(stat1);
 
         restaurant2 = Restaurant.builder()
-                                .manageNo("manage-no")
-                                .sigunName("sigun name 2")
-                                .sigunCode("sigun code 2")
-                                .bizName("biz name 2")
-                                .bizStatus("영업/정상")
-                                .cuisineType("한식")
-                                .roadAddr("road address")
-                                .jibunAddr("jibun address")
-                                .latitude(new BigDecimal("37.401690"))
-                                .longitude(new BigDecimal("126.974500"))
-                                .build();
+            .manageNo("manage-no")
+            .sigunName("sigun name 2")
+            .sigunCode("sigun code 2")
+            .bizName("biz name 2")
+            .bizStatus("영업/정상")
+            .cuisineType("한식")
+            .roadAddr("road address")
+            .jibunAddr("jibun address")
+            .latitude(new BigDecimal("37.401690"))
+            .longitude(new BigDecimal("126.974500"))
+            .build();
 
         entityManager.persist(restaurant2);
 
         stat2 = RestaurantReviewStat.builder()
-                                    .restaurantId(restaurant2.getId())
-                                    .averageScore(3.51)
-                                    .reviewCount(2)
-                                    .build();
+            .restaurantId(restaurant2.getId())
+            .averageScore(3.51)
+            .reviewCount(2)
+            .build();
+
+        user = User.builder()
+            .username("username")
+            .latitude(new BigDecimal(MY_LATITUDE))
+            .longitude(new BigDecimal(MY_LONGITUDE))
+            .build();
 
         entityManager.persist(stat2);
     }
@@ -164,6 +172,15 @@ class RestaurantRepositoryImplTest {
 
         assertThat(result.getContent().get(0).getCuisineType()).isEqualTo(CHINESE_FOOD);
         assertThat(result.getContent().get(1).getCuisineType()).isEqualTo(KOREAN_FOOD);
+    }
+
+    @DisplayName("레스토랑 거리순 추천 조회 성공")
+    @Test
+    void get_restaurant_recommended_list_success() {
+        List<Restaurant> result = restaurantRepository.findRecommendedRestaurants(user);
+
+        assertThat(result.get(0).getCuisineType()).isEqualTo(KOREAN_FOOD);
+        assertThat(result.get(1).getCuisineType()).isEqualTo(CHINESE_FOOD);
     }
 
 }


### PR DESCRIPTION
## 💻 작업 내역

### ✓ 맛집 추천 querydsl 작성 4545e14f90707ebba8dc9ede0f578c3e09a8b1aa
```java
@Override
public List<Restaurant> findRecommendedRestaurants(User user) {
    return jpaQueryFactory.selectFrom(restaurant)
        .leftJoin(restaurantReviewStat)
        .on(restaurant.id.eq(restaurantReviewStat.restaurantId))
        .where(closedEq(), reviewScoreBetweenFourAndFive())
        .orderBy(getDistance(user.getLatitude(), user.getLongitude()).asc())
        .limit(5)
        .fetch();
}
```

- 가장 가까운 맛집 중, `averageScore`이 4이상 5이하인 맛집 5개 리턴
> 기존 요구사항에는 500미터 이내였었는데, 500미터 이내로 설정하게 되면 가게가 없을 때가 많을 것 같아서 다음과 같이 수정하였습니다.

### ✓ 유저 개별 전송 및 비동기 처리 779865123564f610286c6921fa8f0ff90678f2e3

- `@EnableAsync` 어노테이션을 활용하였습니다.

### ✓ 맛집이 없을 경우 예외 처리 1184fbe395097ce21894adb0dbca263d3da833da

**근처 맛집이 있는 경우**
<img width="250" alt="image" src="https://github.com/wanted-pre-onboarding-backend-team-s/bab-doduk/assets/45661217/ea484b47-b70d-409d-8a9e-b68afcb5afad">

**근처 맛집이 없는 경우**
<img src="https://github.com/wanted-pre-onboarding-backend-team-s/bab-doduk/assets/45661217/f75f2060-f4f7-4c60-adbb-574f892d838f" width="300px"></img>

## 🔎 PR 특이 사항
- 이번 기능에서 webClient의 장점이 드러납니다.  
비동기 처리를 하였기 때문에 Non-Blocking을 통해 여러 유저의 요청 url로 빠르게 보낼 수 있습니다.
[https://tecoble.techcourse.co.kr/post/2021-10-20-synchronous-asynchronous/](https://tecoble.techcourse.co.kr/post/2021-10-20-synchronous-asynchronous/)

- 앞선 기능에서 스케쥴러 pool size를 5로 설정하였기 때문에 비동기 함수 실행시 과부화가 없습니다.

